### PR TITLE
Recalculate gap correctly 

### DIFF
--- a/js/demo.js
+++ b/js/demo.js
@@ -289,8 +289,8 @@
         // Distance between 2 slides 
         // The amount to translate the elements that move when we navigate the slideshow
         calculateGap() {
-            const s1 = this.slides[0].DOM.el.getBoundingClientRect();
-            const s2 = this.slides[1].DOM.el.getBoundingClientRect();
+            const s1 = this.slides[this.center].DOM.el.getBoundingClientRect();
+            const s2 = this.slides[this.center + 1].DOM.el.getBoundingClientRect();
             this.gap = MathUtils.distance(s1.left + s1.width/2, s2.left + s2.width/2, s1.top + s1.height/2, s2.top + s2.height/2);
         }
         // Initialize events


### PR DESCRIPTION
when resizing while current slide is not one of the start slides